### PR TITLE
Bump RSpec

### DIFF
--- a/edge.gemspec
+++ b/edge.gemspec
@@ -20,5 +20,5 @@ Gem::Specification.new do |gem|
   gem.add_development_dependency 'pg'
   gem.add_development_dependency 'pry'
   gem.add_development_dependency 'rake'
-  gem.add_development_dependency 'rspec', "~> 3.1.0"
+  gem.add_development_dependency 'rspec', "~> 3.6.0"
 end


### PR DESCRIPTION
In rspec 3.1.x, used a method which does not already exist in Rake, and it was an error in CI.
Ref: https://travis-ci.org/jackc/edge/jobs/230969587

Updated to use the latest rspec to avoid errors.